### PR TITLE
Update react-bootstrap to 0.28.5

### DIFF
--- a/example/Example.jsx
+++ b/example/Example.jsx
@@ -190,8 +190,6 @@ var Example = React.createClass({
                   {links('xlsx')}
                   <li><FileInput extensions={['xlsx', 'ods']} onChange={this.openSpreadsheet} /></li>
                 </ul>
-              </Col>
-              <Col md={3}>
                 <p>CSV format</p>
                 <ul>
                   {links('csv')}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "plexus-validate": "0.0.4",
     "react": "~0.14.7",
     "react-addons-create-fragment": "~0.14.7",
-    "react-bootstrap": "~0.28.3",
+    "react-bootstrap": "~0.28.5",
     "react-date-picker": "~4.0.8",
     "react-dom": "~0.14.7",
     "react-fa": "~4.0.0",


### PR DESCRIPTION
This fixes resizing of the editor on collapsing the examples panel.

react-bootstrap/react-bootstrap#1664
